### PR TITLE
Add Alarmo config to initial setup

### DIFF
--- a/custom_components/zha_lock_manager/translations/en.json
+++ b/custom_components/zha_lock_manager/translations/en.json
@@ -4,9 +4,11 @@
       "step": {
         "user": {
           "title": "Select ZHA Locks",
-          "description": "Pick the Zigbee locks you want to manage.",
+          "description": "Pick the Zigbee locks you want to manage and optionally enable Alarmo.",
           "data": {
-            "locks": "Locks"
+            "locks": "Locks",
+            "alarmo_enabled": "Enable Alarmo integration (Optional)",
+            "alarmo_entity_id": "Alarmo entity_id"
           }
         }
       }


### PR DESCRIPTION
## Summary
- allow enabling Alarmo integration during initial setup
- offer Alarmo entity selector when enabled

## Testing
- `python -m py_compile custom_components/zha_lock_manager/config_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a364c7193c832d9cfe3c9a64dbc3e6