### PR TITLE
Use entity selector for Alarmo entity in options

### DIFF
--- a/custom_components/zha_lock_manager/config_flow.py
+++ b/custom_components/zha_lock_manager/config_flow.py
@@ -142,7 +142,11 @@ class ZLMOptionsFlowHandler(config_entries.OptionsFlow):
             ),
             # Global Alarmo settings, apply to all locks
             vol.Optional(CONF_ALARMO_ENABLED, default=alarmo_enabled_default): bool,
-            vol.Optional(CONF_ALARMO_ENTITY_ID, default=alarmo_entity_default): str,
+            vol.Optional(
+                CONF_ALARMO_ENTITY_ID, default=alarmo_entity_default
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="alarm_control_panel")
+            ),
         }
 
         if user_input is not None:


### PR DESCRIPTION
## Summary
- Replace text input with entity selector for Alarmo entity in options flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a39dad4db8832dbbfbfe1ae3f5e28e